### PR TITLE
feat: support outdoor-only sensor configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,22 @@ Configure outdoor sensor entities to see a **dashed comparison line** on each gr
 - Current outdoor values appear next to indoor readings
 - **Smart recommendations** avoid suggesting ventilation when outdoor air is worse (e.g., "Keep Windows Closed" instead of "Open Window")
 
+### Outdoor-Only Mode
+
+If you're using the card to monitor **only outdoor air quality** (e.g., a weather station or DIY ESPHome ambient sensor), you can configure just the `outdoor_*_entity` options. The card will:
+
+- Render outdoor entities as primary graph lines
+- Compute the status badge from the outdoor values using the same WHO thresholds
+- **Hide the recommendation strip** — actions like "Open Window" or "Run Air Purifier" don't apply to ambient air
+
+```yaml
+type: custom:air-quality-card
+name: Outdoor Air Quality
+outdoor_pm25_entity: sensor.outdoor_pm25
+outdoor_pm10_entity: sensor.outdoor_pm10
+outdoor_temperature_entity: sensor.outdoor_temperature
+```
+
 ## Built-in Recommendations
 
 The card automatically generates actionable recommendations based on your sensor readings -- no template sensors needed. It evaluates CO, CO2, PM2.5, PM10, HCHO, tVOC, and humidity levels, and when outdoor sensors are configured, it avoids suggesting ventilation when outdoor air is worse.

--- a/air-quality-card.js
+++ b/air-quality-card.js
@@ -35,13 +35,21 @@ class AirQualityCard extends HTMLElement {
   setConfig(config) {
     if (!config) throw new Error('Invalid configuration');
 
-    // Validate that at least one sensor entity is configured
-    const hasEntity = config.co2_entity || config.pm25_entity || config.pm1_entity ||
-      config.pm10_entity || config.pm03_entity || config.pm4_entity ||
-      config.hcho_entity || config.tvoc_entity || config.nox_entity ||
-      config.co_entity || config.radon_entity ||
-      config.radon_longterm_entity || config.humidity_entity || config.temperature_entity;
-    if (!hasEntity) {
+    const indoorEntityKeys = [
+      'co2_entity', 'pm25_entity', 'pm1_entity', 'pm10_entity', 'pm03_entity',
+      'pm4_entity', 'hcho_entity', 'tvoc_entity', 'nox_entity', 'co_entity',
+      'radon_entity', 'radon_longterm_entity', 'humidity_entity', 'temperature_entity'
+    ];
+    const outdoorEntityKeys = [
+      'outdoor_co2_entity', 'outdoor_pm25_entity', 'outdoor_pm1_entity',
+      'outdoor_pm10_entity', 'outdoor_pm03_entity', 'outdoor_hcho_entity',
+      'outdoor_tvoc_entity', 'outdoor_co_entity', 'outdoor_humidity_entity',
+      'outdoor_temperature_entity'
+    ];
+    const hasIndoor = indoorEntityKeys.some(k => config[k]);
+    const hasOutdoor = outdoorEntityKeys.some(k => config[k]);
+
+    if (!hasIndoor && !hasOutdoor) {
       throw new Error('Please configure at least one sensor entity');
     }
 
@@ -52,6 +60,32 @@ class AirQualityCard extends HTMLElement {
       radon_unit: 'auto',
       ...config
     };
+
+    // Outdoor-only mode: when no indoor entities are set, promote each outdoor
+    // entity into its primary slot so the existing render pipeline shows it.
+    // Recommendations are suppressed in this mode since they assume indoor context.
+    this._outdoorOnly = !hasIndoor;
+    if (this._outdoorOnly) {
+      const promotionMap = {
+        outdoor_co2_entity: 'co2_entity',
+        outdoor_pm25_entity: 'pm25_entity',
+        outdoor_pm1_entity: 'pm1_entity',
+        outdoor_pm10_entity: 'pm10_entity',
+        outdoor_pm03_entity: 'pm03_entity',
+        outdoor_hcho_entity: 'hcho_entity',
+        outdoor_tvoc_entity: 'tvoc_entity',
+        outdoor_co_entity: 'co_entity',
+        outdoor_humidity_entity: 'humidity_entity',
+        outdoor_temperature_entity: 'temperature_entity'
+      };
+      for (const [outdoorKey, primaryKey] of Object.entries(promotionMap)) {
+        if (this._config[outdoorKey] && !this._config[primaryKey]) {
+          this._config[primaryKey] = this._config[outdoorKey];
+          delete this._config[outdoorKey];
+        }
+      }
+    }
+
     this._rendered = false;
     this._historyLoaded = false;
   }
@@ -458,6 +492,10 @@ class AirQualityCard extends HTMLElement {
   }
 
   _getRecommendation() {
+    // Outdoor-only mode: recommendations assume an indoor context (open window,
+    // run air purifier, etc.) and are nonsensical when the user is monitoring
+    // ambient air quality. Hide the recommendation strip entirely.
+    if (this._outdoorOnly) return null;
     const co = this._config.co_entity ? this._getNumericState(this._config.co_entity) : 0;
     const co2 = this._config.co2_entity ? this._getNumericState(this._config.co2_entity) : 0;
     const pm25 = this._config.pm25_entity ? this._getNumericState(this._config.pm25_entity) : 0;
@@ -819,6 +857,7 @@ class AirQualityCard extends HTMLElement {
             </div>
           </div>
 
+          ${!this._outdoorOnly ? `
           <div class="recommendation" id="recommendation">
             <ha-icon id="rec-icon" icon="mdi:check-circle"></ha-icon>
             <div class="recommendation-text">
@@ -826,6 +865,7 @@ class AirQualityCard extends HTMLElement {
               <div class="recommendation-subtitle" id="rec-subtitle">Air quality is within healthy limits</div>
             </div>
           </div>
+          ` : ''}
 
           <div class="radon-advisory" id="radon-advisory" style="display:none">
             <ha-icon id="radon-advisory-icon" icon="mdi:radioactive"></ha-icon>

--- a/test.js
+++ b/test.js
@@ -493,6 +493,74 @@ try {
 assert(configValid, 'radon_longterm_entity alone is valid config');
 
 // ============================================================
+// OUTDOOR-ONLY MODE TESTS
+// ============================================================
+
+section('Outdoor-Only Mode');
+
+// Outdoor-only config is valid
+let outdoorOnlyCard = new CardClass();
+let outdoorOnlyValid = true;
+try {
+  outdoorOnlyCard.setConfig({ outdoor_pm25_entity: 'sensor.outdoor_pm25' });
+} catch (e) {
+  outdoorOnlyValid = false;
+}
+assert(outdoorOnlyValid, 'outdoor_pm25_entity alone is valid config');
+assert(outdoorOnlyCard._outdoorOnly === true, '_outdoorOnly flag set when only outdoor entities configured');
+assert(outdoorOnlyCard._config.pm25_entity === 'sensor.outdoor_pm25', 'outdoor_pm25_entity promoted to pm25_entity');
+assert(outdoorOnlyCard._config.outdoor_pm25_entity === undefined, 'outdoor_pm25_entity removed after promotion');
+
+// Multiple outdoor entities all promote
+const multiOutdoor = new CardClass();
+multiOutdoor.setConfig({
+  outdoor_co2_entity: 'sensor.out_co2',
+  outdoor_pm25_entity: 'sensor.out_pm25',
+  outdoor_temperature_entity: 'sensor.out_temp'
+});
+assert(multiOutdoor._outdoorOnly === true, 'multi-outdoor: _outdoorOnly true');
+assert(multiOutdoor._config.co2_entity === 'sensor.out_co2', 'outdoor_co2_entity promoted');
+assert(multiOutdoor._config.pm25_entity === 'sensor.out_pm25', 'outdoor_pm25_entity promoted');
+assert(multiOutdoor._config.temperature_entity === 'sensor.out_temp', 'outdoor_temperature_entity promoted');
+
+// Indoor + outdoor: no promotion, outdoor remains as overlay
+const mixed = new CardClass();
+mixed.setConfig({
+  pm25_entity: 'sensor.indoor_pm25',
+  outdoor_pm25_entity: 'sensor.outdoor_pm25'
+});
+assert(mixed._outdoorOnly === false, 'mixed indoor+outdoor: _outdoorOnly false');
+assert(mixed._config.pm25_entity === 'sensor.indoor_pm25', 'mixed: indoor entity preserved');
+assert(mixed._config.outdoor_pm25_entity === 'sensor.outdoor_pm25', 'mixed: outdoor stays for overlay');
+
+// Empty config still throws
+let emptyThrew = false;
+try {
+  new CardClass().setConfig({});
+} catch (e) {
+  emptyThrew = true;
+}
+assert(emptyThrew, 'empty config still throws');
+
+// Recommendations suppressed in outdoor-only mode
+const outdoorRec = new CardClass();
+outdoorRec.setConfig({ outdoor_co2_entity: 'sensor.out_co2' });
+outdoorRec._hass = card._hass;
+outdoorRec._hass.states['sensor.out_co2'] = { state: '2000', attributes: {} }; // would normally trigger "Ventilate Now"
+assert(outdoorRec._getRecommendation() === null, '_getRecommendation returns null in outdoor-only mode');
+
+// Recommendations work normally with indoor entity
+const indoorRec = new CardClass();
+indoorRec.setConfig({ co2_entity: 'sensor.in_co2' });
+indoorRec._hass = card._hass;
+indoorRec._hass.states['sensor.in_co2'] = { state: '2000', attributes: {} };
+assert(indoorRec._getRecommendation() === 'Ventilate Now', 'indoor mode: _getRecommendation works normally');
+
+// Restore card._config for downstream tests
+card._config = { name: 'Test', hours_to_show: 24, temperature_unit: 'auto' };
+card._outdoorOnly = false;
+
+// ============================================================
 // CARD SIZE TESTS
 // ============================================================
 


### PR DESCRIPTION
Closes #25.

## Summary

Allows the card to be configured with only `outdoor_*_entity` options, without requiring any indoor sensor. Useful for users monitoring ambient/outdoor air quality only (e.g., a weather station, DIY ESPHome ambient sensor).

## Changes

- `setConfig` now accepts outdoor-only configurations.
- When no indoor entity is configured, outdoor entities are auto-promoted to their primary slot (`outdoor_co2_entity` → `co2_entity`) so the existing render pipeline shows them. The `_outdoorOnly` flag is set.
- In outdoor-only mode the recommendation strip is suppressed — actions like "Open Window" or "Run Air Purifier" don't apply to ambient air. The status badge still computes from outdoor values using the same WHO thresholds.
- Mixed configs (indoor + outdoor) behave exactly as before: outdoor entities render as dashed overlays, recommendations work normally.

## Test plan

- [x] `node test.js` — 220 passed (11 new outdoor-only tests covering: validation passes for outdoor-only, entity promotion is correct, mixed configs still preserve outdoor as overlay, empty config still throws, recommendations are suppressed only in outdoor-only mode)
- [ ] Manual verification in HA: configure an outdoor-only card and confirm graphs render with outdoor data, status badge updates, and the recommendation strip is hidden
- [ ] Manual verification in HA: existing indoor + outdoor configs still show dashed overlays as before

## Notes for maintainer

I deliberately did **not** bump `CARD_VERSION` so multiple in-flight PRs can land independently — please bump to the next minor (e.g. `2.9.0`) on merge.