### PR TITLE
feat: optional min/max per metric (show_min_max)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ outdoor_pm25_entity: sensor.outdoor_pm25
 | `hours_to_show` | number | No | 24 | Hours of history to display (1-168) |
 | `temperature_unit` | string | No | "auto" | Temperature unit: "auto" (detect from HA), "F" (Fahrenheit), or "C" (Celsius) |
 | `radon_unit` | string | No | "auto" | Radon unit: "auto" (detect from sensor), "pCi/L" (US), or "Bq/m3" (International) |
+| `show_min_max` | boolean | No | `false` | Show the min/max value seen over the displayed time window beneath each metric |
 | `outdoor_co2_entity` | string | No | - | Outdoor CO2 sensor for comparison |
 | `outdoor_pm25_entity` | string | No | - | Outdoor PM2.5 sensor for comparison |
 | `outdoor_pm1_entity` | string | No | - | Outdoor PM1 sensor for comparison |

--- a/air-quality-card.js
+++ b/air-quality-card.js
@@ -50,10 +50,49 @@ class AirQualityCard extends HTMLElement {
       hours_to_show: 24,
       temperature_unit: 'auto',
       radon_unit: 'auto',
+      show_min_max: false,
       ...config
     };
     this._rendered = false;
     this._historyLoaded = false;
+  }
+
+  _getMinMax(data) {
+    if (!data || !data.length) return null;
+    let min = data[0].value;
+    let max = data[0].value;
+    for (let i = 1; i < data.length; i++) {
+      if (data[i].value < min) min = data[i].value;
+      if (data[i].value > max) max = data[i].value;
+    }
+    return { min, max };
+  }
+
+  _formatGraphValue(value, unit) {
+    if (unit === 'pCi/L') return value.toFixed(1);
+    if (unit === 'ppm' || unit === 'ppb' || unit === 'p/0.1L' || unit === 'Bq/m³' || unit === '%' || unit === '°F' || unit === '°C') {
+      return Math.round(value);
+    }
+    return value.toFixed(1);
+  }
+
+  _updateMinMaxDisplay(graphId, data, unit) {
+    const minMax = this._getMinMax(data);
+    if (!minMax) return;
+    const container = this.shadowRoot.getElementById(`${graphId}-graph-container`);
+    if (!container) return;
+    let minmaxEl = this.shadowRoot.getElementById(`${graphId}-minmax`);
+    if (!minmaxEl) {
+      const header = container.querySelector('.graph-header');
+      if (!header) return;
+      minmaxEl = document.createElement('div');
+      minmaxEl.className = 'graph-minmax';
+      minmaxEl.id = `${graphId}-minmax`;
+      header.insertAdjacentElement('afterend', minmaxEl);
+    }
+    const minStr = this._formatGraphValue(minMax.min, unit);
+    const maxStr = this._formatGraphValue(minMax.max, unit);
+    minmaxEl.innerHTML = `<span class="arrow">↓</span>${minStr} · <span class="arrow">↑</span>${maxStr} ${unit}`;
   }
 
   set hass(hass) {
@@ -708,6 +747,21 @@ class AirQualityCard extends HTMLElement {
           margin-left: 4px;
           padding: 1px 4px;
           border-radius: 3px;
+        }
+
+        .graph-minmax {
+          font-size: 0.7em;
+          color: var(--secondary-text-color);
+          opacity: 0.7;
+          text-align: right;
+          margin-top: -4px;
+          margin-bottom: 4px;
+          letter-spacing: 0.3px;
+        }
+
+        .graph-minmax .arrow {
+          font-weight: 600;
+          margin: 0 1px;
         }
 
         .graph-wrapper {
@@ -1538,6 +1592,10 @@ class AirQualityCard extends HTMLElement {
     const timeAxis = this.shadowRoot.getElementById(`${graphId}-time-axis`);
     if (!svg || !data.length) return;
 
+    if (this._config.show_min_max) {
+      this._updateMinMaxDisplay(graphId, data, unit);
+    }
+
     const width = 300;
     const height = 50;
     const padding = 2;
@@ -1887,7 +1945,8 @@ if (LitElement && !customElements.get('air-quality-card-editor')) {
         hours_to_show: 'Graph History',
         temperature_unit: 'Temperature Unit',
         radon_unit: 'Radon Unit',
-        tvoc_unit: 'tVOC Measurement Type'
+        tvoc_unit: 'tVOC Measurement Type',
+        show_min_max: 'Show min/max for each metric'
       };
       return labels[schema.name] || schema.name;
     }
@@ -2000,6 +2059,7 @@ if (LitElement && !customElements.get('air-quality-card-editor')) {
           schema: [
             { name: 'air_quality_entity', selector: { entity: { domain: 'sensor' } } },
             { name: 'hours_to_show', selector: { number: { min: 1, max: 168, mode: 'box', unit_of_measurement: 'hours' } } },
+            { name: 'show_min_max', selector: { boolean: {} } },
             { name: 'temperature_unit', selector: { select: { options: [{ value: 'auto', label: 'Auto (from HA)' }, { value: 'F', label: 'Fahrenheit (°F)' }, { value: 'C', label: 'Celsius (°C)' }], mode: 'dropdown' } } },
             { name: 'radon_unit', selector: { select: { options: [{ value: 'auto', label: 'Auto (from sensor)' }, { value: 'pCi/L', label: 'pCi/L (US)' }, { value: 'Bq/m³', label: 'Bq/m³ (International)' }], mode: 'dropdown' } } },
             { name: 'tvoc_unit', selector: { select: { options: [{ value: 'auto', label: 'Auto-detect' }, { value: 'ppb', label: 'Absolute (ppb)' }, { value: 'index', label: 'VOC Index (Sensirion)' }], mode: 'dropdown' } } },

--- a/test.js
+++ b/test.js
@@ -493,6 +493,51 @@ try {
 assert(configValid, 'radon_longterm_entity alone is valid config');
 
 // ============================================================
+// MIN/MAX HELPER TESTS (issue #23)
+// ============================================================
+
+section('Min/Max Helper');
+
+assert(card._getMinMax(null) === null, 'null data → null');
+assert(card._getMinMax([]) === null, 'empty array → null');
+
+const sample = [
+  { time: 1, value: 5 },
+  { time: 2, value: 10 },
+  { time: 3, value: 2 },
+  { time: 4, value: 8 }
+];
+const mm = card._getMinMax(sample);
+assert(mm && mm.min === 2, '_getMinMax min = 2');
+assert(mm && mm.max === 10, '_getMinMax max = 10');
+
+// Single-point edge case
+const single = card._getMinMax([{ time: 1, value: 7 }]);
+assert(single.min === 7 && single.max === 7, 'single point: min === max');
+
+// All same values
+const flat = card._getMinMax([{ time: 1, value: 4 }, { time: 2, value: 4 }, { time: 3, value: 4 }]);
+assert(flat.min === 4 && flat.max === 4, 'flat data: min === max');
+
+section('Graph value formatting');
+assert(card._formatGraphValue(5.4, 'ppm') === 5, 'ppm rounds');
+assert(card._formatGraphValue(5.4, 'ppb') === 5, 'ppb rounds');
+assert(card._formatGraphValue(5.4, 'Bq/m³') === 5, 'Bq/m³ rounds');
+assert(card._formatGraphValue(5.4, '°C') === 5, '°C rounds');
+assert(card._formatGraphValue(5.45, 'pCi/L') === '5.5', 'pCi/L 1 decimal (rounded)');
+assert(card._formatGraphValue(2.3, 'μg/m³') === '2.3', 'μg/m³ 1 decimal');
+
+// Default config has show_min_max: false (opt-in)
+const defaultCard = new CardClass();
+defaultCard.setConfig({ co2_entity: 'sensor.co2' });
+assert(defaultCard._config.show_min_max === false, 'show_min_max defaults to false');
+
+// User can opt in
+const minMaxCard = new CardClass();
+minMaxCard.setConfig({ co2_entity: 'sensor.co2', show_min_max: true });
+assert(minMaxCard._config.show_min_max === true, 'show_min_max can be enabled');
+
+// ============================================================
 // CARD SIZE TESTS
 // ============================================================
 
@@ -545,7 +590,7 @@ const allLabels = [
   'outdoor_co2_entity', 'outdoor_pm25_entity', 'outdoor_humidity_entity', 'outdoor_temperature_entity',
   'outdoor_co_entity', 'outdoor_hcho_entity', 'outdoor_tvoc_entity',
   'outdoor_pm1_entity', 'outdoor_pm10_entity', 'outdoor_pm03_entity',
-  'air_quality_entity', 'hours_to_show', 'temperature_unit', 'radon_unit'
+  'air_quality_entity', 'hours_to_show', 'temperature_unit', 'radon_unit', 'show_min_max'
 ];
 for (const name of allLabels) {
   const label = editor._computeLabel({ name });


### PR DESCRIPTION
Closes #23.

## Summary

Adds an opt-in \`show_min_max: true\` config option that displays the minimum and maximum value seen over the configured time window for each metric.

## Design choices

- **Opt-in via boolean config** — follows HA's \`show_X\` convention (\`show_state\`, \`show_name\`, etc.). Default is \`false\` so existing dashboards are unchanged.
- **Uses existing history** — no extra network calls. Data is already in \`this._history[metric]\` after \`_loadHistory\` runs.
- **Dynamic DOM injection** — the min/max element is injected into each graph container at render time rather than baked into the 13 graph blocks in \`_initialRender\`. Cleaner diff, single insertion point, no schema explosion.
- **Compact visual**: \`↓ 400 · ↑ 1200 ppm\` — universal arrow symbols, no translation needed (will play nicely with #10).

## Test plan

- [x] \`node test.js\` — 221 passing (12 new: helper edge cases, defaults, opt-in behavior, editor label)
- [ ] Visual smoke test in HA: configure a card with \`show_min_max: true\`, confirm the min/max row appears beneath each metric's header
- [ ] Toggle the option via the visual editor — confirm the row appears/disappears cleanly

## Notes for maintainer

I did **not** bump \`CARD_VERSION\` — will roll forward into rc2.