### PR TITLE
feat: add show_status_banner option to hide recommendation banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ outdoor_pm25_entity: sensor.outdoor_pm25
 | `tvoc_unit` | string | No | "auto" | tVOC measurement type: "auto" (detect from sensor), "ppb" (absolute), or "index" (Sensirion VOC Index) |
 | `nox_unit` | string | No | "auto" | NOx measurement type: "auto" (detect from sensor), "ppb" (absolute), or "index" (Sensirion NOx Index) |
 | `show_min_max` | boolean | No | `false` | Overlay the min/max values of the displayed time window directly at the data points on the graph |
+| `show_status_banner` | boolean | No | `true` | Show or hide the recommendation banner (the "All Good / Ventilate Now / …" strip at the top of the card) |
 | `order` | array | No | default | Custom display order for metrics (see [Sensor Order](#sensor-order)) |
 | `display` | string | No | "full" | "full" (graphs and details), "compact" (status badge only), or "expandable" (compact, tap to expand to full) |
 | `compact_alerts` | boolean | No | `true` | In the compact/collapsed view, show small colored chips naming the sensors currently out of range |

--- a/air-quality-card.js
+++ b/air-quality-card.js
@@ -217,6 +217,7 @@ class AirQualityCard extends HTMLElement {
       temperature_unit: 'auto',
       radon_unit: 'auto',
       show_min_max: false,
+      show_status_banner: true,
       display: 'full',
       compact_alerts: true,
       language: 'auto',
@@ -1569,7 +1570,7 @@ class AirQualityCard extends HTMLElement {
             </div>
           </div>
 
-          ${!this._outdoorOnly ? `
+          ${!this._outdoorOnly && this._config.show_status_banner !== false ? `
           <div class="recommendation" id="recommendation">
             <ha-icon id="rec-icon" icon="mdi:check-circle"></ha-icon>
             <div class="recommendation-text">
@@ -2740,6 +2741,7 @@ if (LitElement && !customElements.get('air-quality-card-editor')) {
       // English fallback for fields added after the translation pack was written.
       const localFallbacks = {
         show_min_max: 'Show min/max for each metric',
+        show_status_banner: 'Show status banner',
         order: 'Sensor Order (list of metric names)',
         display: 'Display Mode',
         tap_action: 'Tap Action',
@@ -2873,6 +2875,7 @@ if (LitElement && !customElements.get('air-quality-card-editor')) {
             { name: 'air_quality_entity', selector: { entity: { domain: 'sensor' } } },
             { name: 'hours_to_show', selector: { number: { min: 1, max: 168, mode: 'box', unit_of_measurement: 'hours' } } },
             { name: 'show_min_max', selector: { boolean: {} } },
+            { name: 'show_status_banner', selector: { boolean: {} } },
             { name: 'order', selector: { select: { multiple: true, mode: 'list', options: [
               { value: 'co', label: 'CO' },
               { value: 'radon', label: 'Radon' },
@@ -2913,7 +2916,7 @@ if (LitElement && !customElements.get('air-quality-card-editor')) {
         <div class="card-config">
           <ha-form
             .hass=${this.hass}
-            .data=${{ compact_alerts: true, ...this._config }}
+            .data=${{ compact_alerts: true, show_status_banner: true, ...this._config }}
             .schema=${this._schema()}
             .computeLabel=${this._computeLabel}
             @value-changed=${this._valueChanged}
@@ -2927,6 +2930,7 @@ if (LitElement && !customElements.get('air-quality-card-editor')) {
       // compact_alerts is injected into the form data as default-true; don't
       // persist it to YAML unless the user actually turned it off.
       if (newConfig.compact_alerts === true) delete newConfig.compact_alerts;
+      if (newConfig.show_status_banner === true) delete newConfig.show_status_banner;
       this.dispatchEvent(new CustomEvent('config-changed', {
         detail: { config: newConfig },
         bubbles: true,


### PR DESCRIPTION
## Summary

Adds a new `show_status_banner` configuration option that allows users to hide the All Good / recommendation banner at the top of the card. This is useful for dashboards where the card is used purely for temperature and humidity monitoring, saving valuable screen space.

## Changes

- **air-quality-card.js** — Added `show_status_banner` boolean config option (default: `true`). When set to `false`, the recommendation banner is not rendered.
- **air-quality-card.js** — Added `show_status_banner` toggle to the visual editor under the **Advanced Options** section, alongside existing options like `show_min_max` and `hours_to_show`.
- **README.md** — Added `show_status_banner` to the configuration options table.

## Configuration

```yaml
type: custom:air-quality-card
temperature_entity: sensor.outdoor_temperature
humidity_entity: sensor.outdoor_humidity
show_status_banner: false
```

## Behavior

- Default is `true` — fully backwards compatible, no existing configurations are affected.
- When set to `false`, the All Good / recommendation banner (including actionable recommendations like "Open Window" or "Run Air Purifier") is hidden.
- The graphs, current values, and all other card elements remain visible.

## Use Case

Users monitoring only temperature and humidity (e.g. an outdoor sensor like in the screenshot below) don't need air quality recommendations. Hiding the banner makes the card more compact and focused.

## Testing

- Verified banner hides correctly when `show_status_banner: false` is set
- Verified default behavior (`true`) is unchanged
- Verified toggle appears in the visual editor under Advanced Options
- Verified no visual regressions on existing configurations